### PR TITLE
fix Warning: Calling depends_on macos: "10.12" is deprecated

### DIFF
--- a/Casks/dvc.rb
+++ b/Casks/dvc.rb
@@ -5,7 +5,7 @@ cask 'dvc' do
   url "https://github.com/iterative/dvc/releases/download/#{version}/dvc-#{version}.pkg"
   sha256 :no_check
 
-  depends_on macos: '>= 10.12'
+  depends_on macos: :sierra
 
   pkg "dvc-#{version}.pkg"
 


### PR DESCRIPTION
```
==> Upgrading 1 outdated package:
iterative/dvc/dvc 0.56.0 -> 0.57.0
Warning: Calling depends_on macos: "10.12" is deprecated and will be disabled on 2019-10-15! Use depends_on macos: :sierra instead.
Please report this to the iterative/dvc tap, or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/iterative/homebrew-dvc/Casks/dvc.rb:8
```