### PR TITLE
fix GHA multiline behavior

### DIFF
--- a/.github/workflows/create_pr.yaml
+++ b/.github/workflows/create_pr.yaml
@@ -20,7 +20,8 @@ jobs:
       env:
         HOMEBREW_GITHUB_API_TOKEN: ${{secrets.TOKEN}}
       # NOTE: Hint jmespath<1.0 due to https://github.com/ddelange/pipgrip/issues/77
-      run: brew bump-formula-pr dvc --no-browse --version $(cat version) --verbose \
-        --python-package-name=dvc[all] \
-        --python-extra-packages=jmespath<1.0 \
+      run: >-
+        brew bump-formula-pr dvc --no-browse --version $(cat version) --verbose
+        --python-package-name=dvc[all]
+        --python-extra-packages=jmespath<1.0
         --python-exclude-packages=protobuf,pyarrow,six,tabulate


### PR DESCRIPTION
GHA leaves backslashes in multi-line run commands, use folded syntax instead (https://github.com/iterative/homebrew-dvc/runs/6152810600?check_suite_focus=true)